### PR TITLE
Simplified ISR entry/exit sequences for imrpoved size and speed.

### DIFF
--- a/software/full-crt.S
+++ b/software/full-crt.S
@@ -24,79 +24,49 @@ _start:
   j 1b
 
 _isr:
-  addi sp, sp, -272
+  // Save all registers in the response of the caller on the stack.
+  addi sp, sp, -64
+  sw ra, 60(sp)
+  sw t0, 56(sp)
+  sw t1, 52(sp)
+  sw t2, 48(sp)
+  sw t3, 44(sp)
+  sw t4, 40(sp)
+  sw t5, 36(sp)
+  sw t6, 32(sp)
+  sw a0, 28(sp)
+  sw a1, 24(sp)
+  sw a2, 20(sp)
+  sw a3, 16(sp)
+  sw a4, 12(sp)
+  sw a5,  8(sp)
+  sw a6,  4(sp)
+  sw a7,  0(sp)
 
-  sw x1, 1*REGBYTES(sp)
-  sw x2, 2*REGBYTES(sp)
-  sw x3, 3*REGBYTES(sp)
-  sw x4, 4*REGBYTES(sp)
-  sw x5, 5*REGBYTES(sp)
-  sw x6, 6*REGBYTES(sp)
-  sw x7, 7*REGBYTES(sp)
-  sw x8, 8*REGBYTES(sp)
-  sw x9, 9*REGBYTES(sp)
-  sw x10, 10*REGBYTES(sp)
-  sw x11, 11*REGBYTES(sp)
-  sw x12, 12*REGBYTES(sp)
-  sw x13, 13*REGBYTES(sp)
-  sw x14, 14*REGBYTES(sp)
-  sw x15, 15*REGBYTES(sp)
-  sw x16, 16*REGBYTES(sp)
-  sw x17, 17*REGBYTES(sp)
-  sw x18, 18*REGBYTES(sp)
-  sw x19, 19*REGBYTES(sp)
-  sw x20, 20*REGBYTES(sp)
-  sw x21, 21*REGBYTES(sp)
-  sw x22, 22*REGBYTES(sp)
-  sw x23, 23*REGBYTES(sp)
-  sw x24, 24*REGBYTES(sp)
-  sw x25, 25*REGBYTES(sp)
-  sw x26, 26*REGBYTES(sp)
-  sw x27, 27*REGBYTES(sp)
-  sw x28, 28*REGBYTES(sp)
-  sw x29, 29*REGBYTES(sp)
-  sw x30, 30*REGBYTES(sp)
-  sw x31, 31*REGBYTES(sp)
-
-  // Prepare the input registers for the exception handler.
+  // Prepare the input registers to call the exception handler.
   csrr a0, mcause
   csrr a1, mepc
   mv   a2, sp
   jal  handle_exception
   csrw mepc, a0
 
-  lw x1, 1*REGBYTES(sp)
-  lw x2, 2*REGBYTES(sp)
-  lw x3, 3*REGBYTES(sp)
-  lw x4, 4*REGBYTES(sp)
-  lw x5, 5*REGBYTES(sp)
-  lw x6, 6*REGBYTES(sp)
-  lw x7, 7*REGBYTES(sp)
-  lw x8, 8*REGBYTES(sp)
-  lw x9, 9*REGBYTES(sp)
-  lw x10, 10*REGBYTES(sp)
-  lw x11, 11*REGBYTES(sp)
-  lw x12, 12*REGBYTES(sp)
-  lw x13, 13*REGBYTES(sp)
-  lw x14, 14*REGBYTES(sp)
-  lw x15, 15*REGBYTES(sp)
-  lw x16, 16*REGBYTES(sp)
-  lw x17, 17*REGBYTES(sp)
-  lw x18, 18*REGBYTES(sp)
-  lw x19, 19*REGBYTES(sp)
-  lw x20, 20*REGBYTES(sp)
-  lw x21, 21*REGBYTES(sp)
-  lw x22, 22*REGBYTES(sp)
-  lw x23, 23*REGBYTES(sp)
-  lw x24, 24*REGBYTES(sp)
-  lw x25, 25*REGBYTES(sp)
-  lw x26, 26*REGBYTES(sp)
-  lw x27, 27*REGBYTES(sp)
-  lw x28, 28*REGBYTES(sp)
-  lw x29, 29*REGBYTES(sp)
-  lw x30, 30*REGBYTES(sp)
-  lw x31, 31*REGBYTES(sp)
-
-  addi sp, sp, 272
+  // Restore all registers in the response of the caller from the stack.
+  lw ra, 60(sp)
+  lw t0, 56(sp)
+  lw t1, 52(sp)
+  lw t2, 48(sp)
+  lw t3, 44(sp)
+  lw t4, 40(sp)
+  lw t5, 36(sp)
+  lw t6, 32(sp)
+  lw a0, 28(sp)
+  lw a1, 24(sp)
+  lw a2, 20(sp)
+  lw a3, 16(sp)
+  lw a4, 12(sp)
+  lw a5,  8(sp)
+  lw a6,  4(sp)
+  lw a7,  0(sp)
+  addi sp, sp, 64
 
   mret

--- a/software/full-crt.S
+++ b/software/full-crt.S
@@ -1,5 +1,4 @@
 #include "orca_csrs.h"
-#define REGBYTES 4
 
 .section .text.init
 //Currently we rely on


### PR DESCRIPTION
Only the registers in the response of the caller have to be saved/restored on/from the stack (cmp. RISC-V ISA Spec., Volume 1, Version 2.2).

This sequence works in my project. However, note that I do not use the provided `full-ctr.S` in my project, but a from-scratch developed custom one instead (priority decoding of MEIMASK and MEIPEND in assembler). Nonetheless, my custom code ultimately calls C handler routines and I could not see any issues.