### PR TITLE
Align INTERRUPT_VECTOR documentation with the HDL behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Address that the first instruction to be executed at reset is located.
 
 ### `INTERRUPT_VECTOR` (default = 0x0000 0200)
 
-Address that will be jumped to when an interrupt is received.
+Reset value of the `mtvec` register. The register defines the address of the
+first instruction to be executed on machine traps (i.e., interrupts and 
+exceptions). The value of `mtvec` can be changed via software after reset.
 
 ### `MAX_IFETCHES_IN_FLIGHT` (default = 1)
 


### PR DESCRIPTION
This is a proposed documentation change to reflect the behavior of the most recent HDL code.