### PR TITLE
HEX Error - make run

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ To build the toolchain, set `RISCV_INSTALL` to be the destination directory for
 the toolchain, for instance `/opt/riscv/`, then run
 `GIT_TOP/tools/riscv-toolchain/build-toolchain.sh`.
 
+Path
+-----------------
+We need to add environment variables to our bashrc file. `nano ~/.bashrc`
+
+export QSYS_ROOTDIR="~/intelFPGA_lite/17.1/quartus/sopc_builder/bin"
+export PATH=$PATH:~/intelFPGA_lite/17.1/quartus/sopc_builder/bin
+export PATH=$PATH:~/intelFPGA_lite/17.1/quartus/bin/
+
+If your language is Turkish:
+export LC_ALL=en_US.UTF-8
+
 Sample Systems
 --------------
 

--- a/systems/de2-115/README.md
+++ b/systems/de2-115/README.md
@@ -22,6 +22,10 @@ The Makefile includes pgm and run targets.  `make pgm` will download the
 bitstream to the board.  `make run` will load the program built from the
 software/ directory into instruction memory and reset the processor.
 
+Outputs cannot be seen on HEX when using make run. You can use the 
+`make terminal-run` command to see program outputs. In this way,
+outputs can be seen via terminal.
+
 
 ## Changing Only ORCA Parameters
 


### PR DESCRIPTION
In case of using the orca repository, an error is received when the path is not added.The possible solution of the error is added to the orca/README.md file.When using the orca repository, the outputs cannot be seen on HEXs.The possible solution of the error is added to the orca/systems/de2-115/README.md file.